### PR TITLE
Changes for Win32 building

### DIFF
--- a/autoparamDriverSup/src/Makefile
+++ b/autoparamDriverSup/src/Makefile
@@ -25,7 +25,7 @@ DBD += autoparamDriver.dbd
 # specify all source files to be compiled and added to the library
 autoparamDriver_SRCS += autoparamDriver.cpp
 
-autoparamDriver_LIBS += $(EPICS_BASE_IOC_LIBS)
+autoparamDriver_LIBS += asyn $(EPICS_BASE_IOC_LIBS)
 
 # install these include files
 INC += autoparamDriver.h

--- a/autoparamDriverSup/src/Makefile
+++ b/autoparamDriverSup/src/Makefile
@@ -17,6 +17,9 @@ USR_CXXFLAGS_Linux += --std=c++03 -fvisibility=hidden
 LIBRARY_IOC += autoparamDriver
 SHRLIB_VERSION = 1
 
+API_HEADER = autoparamDriverAPI.h
+autoparamDriver_API = autoparamDriver
+
 # xxxRecord.h will be created from xxxRecord.dbd
 #DBDINC += xxxRecord
 # install autoparamDriver.dbd into <top>/dbd

--- a/autoparamDriverSup/src/Makefile
+++ b/autoparamDriverSup/src/Makefile
@@ -11,16 +11,27 @@ include $(TOP)/configure/CONFIG
 
 USR_CXXFLAGS_Linux += --std=c++03 -fvisibility=hidden
 
+ifndef BASE_7_0
+  $(error "Unsupported EPICS version, autoparamDriver needs EPICS 7")
+endif
+
 #==================================================
 # build a support library
 
 LIBRARY_IOC += autoparamDriver
 SHRLIB_VERSION = 2
 
+# Install the API header. If EPICS is older than 7.0.4, use a pre-built header.
+ifeq ($(if $(wildcard $(TOOLS)/makeAPIheader.pl),YES,NO),YES)
 API_HEADER = autoparamDriverAPI.h
 autoparamDriver_API = autoparamDriver
+else
+INC = autoparamDriverAPI.h
+$(COMMON_DIR)/autoparamDriverAPI.h: autoparamDriverAPI_prebuilt.h
+	$(CP) $< $@
+USR_CPPFLAGS += -DBUILDING_autoparamDriver_API
+endif
 
-# xxxRecord.h will be created from xxxRecord.dbd
 #DBDINC += xxxRecord
 # install autoparamDriver.dbd into <top>/dbd
 DBD += autoparamDriver.dbd

--- a/autoparamDriverSup/src/Makefile
+++ b/autoparamDriverSup/src/Makefile
@@ -15,7 +15,7 @@ USR_CXXFLAGS_Linux += --std=c++03 -fvisibility=hidden
 # build a support library
 
 LIBRARY_IOC += autoparamDriver
-SHRLIB_VERSION = 1
+SHRLIB_VERSION = 2
 
 API_HEADER = autoparamDriverAPI.h
 autoparamDriver_API = autoparamDriver

--- a/autoparamDriverSup/src/autoparamDriver.cpp
+++ b/autoparamDriverSup/src/autoparamDriver.cpp
@@ -588,12 +588,12 @@ void Driver::registerHandlers(std::string const &function,
 }
 
 template AUTOPARAMDRIVER_API void epicsStdCall
-Driver::registerHandlers<epicsInt32>(std::string epicsStdCall const &function,
+Driver::registerHandlers<epicsInt32>(std::string  const &function,
                                      Handlers<epicsInt32>::ReadHandler reader,
                                      Handlers<epicsInt32>::WriteHandler writer,
                                      InterruptRegistrar intrRegistrar);
 template AUTOPARAMDRIVER_API void epicsStdCall
-Driver::registerHandlers<epicsInt64>(std::string epicsStdCall const &function,
+Driver::registerHandlers<epicsInt64>(std::string  const &function,
                                      Handlers<epicsInt64>::ReadHandler reader,
                                      Handlers<epicsInt64>::WriteHandler writer,
                                      InterruptRegistrar intrRegistrar);
@@ -661,7 +661,7 @@ asynStatus Driver::doCallbacksArray(DeviceVariable const &var, Array<T> &value,
 }
 
 template AUTOPARAMDRIVER_API asynStatus epicsStdCall
-Driver::doCallbacksArray<epicsInt8>(DeviceVariable epicsStdCall const &var,
+Driver::doCallbacksArray<epicsInt8>(DeviceVariable const &var,
                                     Array<epicsInt8> &value, asynStatus status,
                                     int alarmStatus, int alarmSeverity);
 template AUTOPARAMDRIVER_API asynStatus epicsStdCall

--- a/autoparamDriverSup/src/autoparamDriver.cpp
+++ b/autoparamDriverSup/src/autoparamDriver.cpp
@@ -9,7 +9,6 @@
 #include <epicsExit.h>
 #include <initHooks.h>
 
-#include <epicsExport.h>
 #include "autoparamDriver.h"
 
 namespace Autoparam {
@@ -574,53 +573,53 @@ void Driver::registerHandlers(std::string const &function,
     m_functionTypes[function] = Handlers<T>::type;
 }
 
-template epicsShareFunc void
-Driver::registerHandlers<epicsInt32>(std::string const &function,
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<epicsInt32>(std::string epicsStdCall const &function,
                                      Handlers<epicsInt32>::ReadHandler reader,
                                      Handlers<epicsInt32>::WriteHandler writer,
                                      InterruptRegistrar intrRegistrar);
-template epicsShareFunc void
-Driver::registerHandlers<epicsInt64>(std::string const &function,
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<epicsInt64>(std::string epicsStdCall const &function,
                                      Handlers<epicsInt64>::ReadHandler reader,
                                      Handlers<epicsInt64>::WriteHandler writer,
                                      InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<epicsFloat64>(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<epicsFloat64>(
     std::string const &function, Handlers<epicsFloat64>::ReadHandler reader,
     Handlers<epicsFloat64>::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<epicsUInt32>(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<epicsUInt32>(
     std::string const &function, Handlers<epicsUInt32>::ReadHandler reader,
     Handlers<epicsUInt32>::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<Octet>(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Octet>(
     std::string const &function, Handlers<Octet>::ReadHandler reader,
     Handlers<Octet>::WriteHandler writer, InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<Array<epicsInt8> >(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsInt8> >(
     std::string const &function,
     Handlers<Array<epicsInt8> >::ReadHandler reader,
     Handlers<Array<epicsInt8> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<Array<epicsInt16> >(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsInt16> >(
     std::string const &function,
     Handlers<Array<epicsInt16> >::ReadHandler reader,
     Handlers<Array<epicsInt16> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<Array<epicsInt32> >(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsInt32> >(
     std::string const &function,
     Handlers<Array<epicsInt32> >::ReadHandler reader,
     Handlers<Array<epicsInt32> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<Array<epicsInt64> >(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsInt64> >(
     std::string const &function,
     Handlers<Array<epicsInt64> >::ReadHandler reader,
     Handlers<Array<epicsInt64> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<Array<epicsFloat32> >(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsFloat32> >(
     std::string const &function,
     Handlers<Array<epicsFloat32> >::ReadHandler reader,
     Handlers<Array<epicsFloat32> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template epicsShareFunc void Driver::registerHandlers<Array<epicsFloat64> >(
+template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsFloat64> >(
     std::string const &function,
     Handlers<Array<epicsFloat64> >::ReadHandler reader,
     Handlers<Array<epicsFloat64> >::WriteHandler writer,
@@ -639,23 +638,23 @@ asynStatus Driver::doCallbacksArray(DeviceVariable const &var, Array<T> &value,
     return doCallbacksArrayDispatch(var.asynIndex(), value);
 }
 
-template epicsShareFunc asynStatus
-Driver::doCallbacksArray<epicsInt8>(DeviceVariable const &var,
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::doCallbacksArray<epicsInt8>(DeviceVariable epicsStdCall const &var,
                                     Array<epicsInt8> &value, asynStatus status,
                                     int alarmStatus, int alarmSeverity);
-template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsInt16>(
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsInt16>(
     DeviceVariable const &var, Array<epicsInt16> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
-template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsInt32>(
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsInt32>(
     DeviceVariable const &var, Array<epicsInt32> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
-template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsInt64>(
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsInt64>(
     DeviceVariable const &var, Array<epicsInt64> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
-template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsFloat32>(
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsFloat32>(
     DeviceVariable const &var, Array<epicsFloat32> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
-template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsFloat64>(
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsFloat64>(
     DeviceVariable const &var, Array<epicsFloat64> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
 
@@ -684,27 +683,26 @@ asynStatus Driver::setParam(DeviceVariable const &var, epicsUInt32 value,
     return setUIntDigitalParam(var.asynIndex(), value, mask);
 }
 
-template epicsShareFunc asynStatus Driver::setParam<epicsInt32>(DeviceVariable const &var,
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsInt32>(DeviceVariable const &var,
                                                  epicsInt32 value,
                                                  asynStatus status,
                                                  int alarmStatus,
                                                  int alarmSeverity);
-template epicsShareFunc asynStatus Driver::setParam<epicsInt64>(DeviceVariable const &var,
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsInt64>(DeviceVariable const &var,
                                                  epicsInt64 value,
                                                  asynStatus status,
                                                  int alarmStatus,
                                                  int alarmSeverity);
-template epicsShareFunc asynStatus Driver::setParam<epicsFloat64>(DeviceVariable const &var,
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsFloat64>(DeviceVariable const &var,
                                                    epicsFloat64 value,
                                                    asynStatus status,
                                                    int alarmStatus,
                                                    int alarmSeverity);
-template epicsShareFunc asynStatus Driver::setParam<Octet>(DeviceVariable const &var,
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<Octet>(DeviceVariable const &var,
                                             Octet value, asynStatus status,
                                             int alarmStatus, int alarmSeverity);
 
-template <> epicsShareFunc
-asynStatus Driver::setParam<epicsUInt32>(DeviceVariable const &var,
+template <> AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsUInt32>(DeviceVariable const &var,
                                          epicsUInt32 value, asynStatus status,
                                          int alarmStatus, int alarmSeverity) {
     return setParam(var, value, 0xffffffff, status, alarmStatus, alarmSeverity);

--- a/autoparamDriverSup/src/autoparamDriver.cpp
+++ b/autoparamDriverSup/src/autoparamDriver.cpp
@@ -583,43 +583,51 @@ Driver::registerHandlers<epicsInt64>(std::string epicsStdCall const &function,
                                      Handlers<epicsInt64>::ReadHandler reader,
                                      Handlers<epicsInt64>::WriteHandler writer,
                                      InterruptRegistrar intrRegistrar);
-template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<epicsFloat64>(
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<epicsFloat64>(
     std::string const &function, Handlers<epicsFloat64>::ReadHandler reader,
     Handlers<epicsFloat64>::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<epicsUInt32>(
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<epicsUInt32>(
     std::string const &function, Handlers<epicsUInt32>::ReadHandler reader,
     Handlers<epicsUInt32>::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
 template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Octet>(
     std::string const &function, Handlers<Octet>::ReadHandler reader,
     Handlers<Octet>::WriteHandler writer, InterruptRegistrar intrRegistrar);
-template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsInt8> >(
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<Array<epicsInt8> >(
     std::string const &function,
     Handlers<Array<epicsInt8> >::ReadHandler reader,
     Handlers<Array<epicsInt8> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsInt16> >(
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<Array<epicsInt16> >(
     std::string const &function,
     Handlers<Array<epicsInt16> >::ReadHandler reader,
     Handlers<Array<epicsInt16> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsInt32> >(
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<Array<epicsInt32> >(
     std::string const &function,
     Handlers<Array<epicsInt32> >::ReadHandler reader,
     Handlers<Array<epicsInt32> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsInt64> >(
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<Array<epicsInt64> >(
     std::string const &function,
     Handlers<Array<epicsInt64> >::ReadHandler reader,
     Handlers<Array<epicsInt64> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsFloat32> >(
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<Array<epicsFloat32> >(
     std::string const &function,
     Handlers<Array<epicsFloat32> >::ReadHandler reader,
     Handlers<Array<epicsFloat32> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template AUTOPARAMDRIVER_API void epicsStdCall Driver::registerHandlers<Array<epicsFloat64> >(
+template AUTOPARAMDRIVER_API void epicsStdCall
+Driver::registerHandlers<Array<epicsFloat64> >(
     std::string const &function,
     Handlers<Array<epicsFloat64> >::ReadHandler reader,
     Handlers<Array<epicsFloat64> >::WriteHandler writer,
@@ -642,21 +650,31 @@ template AUTOPARAMDRIVER_API asynStatus epicsStdCall
 Driver::doCallbacksArray<epicsInt8>(DeviceVariable epicsStdCall const &var,
                                     Array<epicsInt8> &value, asynStatus status,
                                     int alarmStatus, int alarmSeverity);
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsInt16>(
-    DeviceVariable const &var, Array<epicsInt16> &value, asynStatus status,
-    int alarmStatus, int alarmSeverity);
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsInt32>(
-    DeviceVariable const &var, Array<epicsInt32> &value, asynStatus status,
-    int alarmStatus, int alarmSeverity);
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsInt64>(
-    DeviceVariable const &var, Array<epicsInt64> &value, asynStatus status,
-    int alarmStatus, int alarmSeverity);
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsFloat32>(
-    DeviceVariable const &var, Array<epicsFloat32> &value, asynStatus status,
-    int alarmStatus, int alarmSeverity);
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::doCallbacksArray<epicsFloat64>(
-    DeviceVariable const &var, Array<epicsFloat64> &value, asynStatus status,
-    int alarmStatus, int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::doCallbacksArray<epicsInt16>(DeviceVariable const &var,
+                                     Array<epicsInt16> &value,
+                                     asynStatus status, int alarmStatus,
+                                     int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::doCallbacksArray<epicsInt32>(DeviceVariable const &var,
+                                     Array<epicsInt32> &value,
+                                     asynStatus status, int alarmStatus,
+                                     int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::doCallbacksArray<epicsInt64>(DeviceVariable const &var,
+                                     Array<epicsInt64> &value,
+                                     asynStatus status, int alarmStatus,
+                                     int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::doCallbacksArray<epicsFloat32>(DeviceVariable const &var,
+                                       Array<epicsFloat32> &value,
+                                       asynStatus status, int alarmStatus,
+                                       int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::doCallbacksArray<epicsFloat64>(DeviceVariable const &var,
+                                       Array<epicsFloat64> &value,
+                                       asynStatus status, int alarmStatus,
+                                       int alarmSeverity);
 
 template <typename T>
 asynStatus Driver::setParam(DeviceVariable const &var, T value,
@@ -683,28 +701,26 @@ asynStatus Driver::setParam(DeviceVariable const &var, epicsUInt32 value,
     return setUIntDigitalParam(var.asynIndex(), value, mask);
 }
 
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsInt32>(DeviceVariable const &var,
-                                                 epicsInt32 value,
-                                                 asynStatus status,
-                                                 int alarmStatus,
-                                                 int alarmSeverity);
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsInt64>(DeviceVariable const &var,
-                                                 epicsInt64 value,
-                                                 asynStatus status,
-                                                 int alarmStatus,
-                                                 int alarmSeverity);
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsFloat64>(DeviceVariable const &var,
-                                                   epicsFloat64 value,
-                                                   asynStatus status,
-                                                   int alarmStatus,
-                                                   int alarmSeverity);
-template AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<Octet>(DeviceVariable const &var,
-                                            Octet value, asynStatus status,
-                                            int alarmStatus, int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::setParam<epicsInt32>(DeviceVariable const &var, epicsInt32 value,
+                             asynStatus status, int alarmStatus,
+                             int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::setParam<epicsInt64>(DeviceVariable const &var, epicsInt64 value,
+                             asynStatus status, int alarmStatus,
+                             int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::setParam<epicsFloat64>(DeviceVariable const &var, epicsFloat64 value,
+                               asynStatus status, int alarmStatus,
+                               int alarmSeverity);
+template AUTOPARAMDRIVER_API asynStatus epicsStdCall
+Driver::setParam<Octet>(DeviceVariable const &var, Octet value,
+                        asynStatus status, int alarmStatus, int alarmSeverity);
 
-template <> AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsUInt32>(DeviceVariable const &var,
-                                         epicsUInt32 value, asynStatus status,
-                                         int alarmStatus, int alarmSeverity) {
+template <>
+AUTOPARAMDRIVER_API asynStatus epicsStdCall Driver::setParam<epicsUInt32>(
+    DeviceVariable const &var, epicsUInt32 value, asynStatus status,
+    int alarmStatus, int alarmSeverity) {
     return setParam(var, value, 0xffffffff, status, alarmStatus, alarmSeverity);
 }
 

--- a/autoparamDriverSup/src/autoparamDriver.cpp
+++ b/autoparamDriverSup/src/autoparamDriver.cpp
@@ -9,8 +9,12 @@
 #include <epicsExit.h>
 #include <initHooks.h>
 
-#define epicsExportSharedSymbols
+#include <epicsExport.h>
 #include "autoparamDriver.h"
+
+#ifdef _MSC_VER
+#define __attribute__(x)
+#endif /* ifdef _MSC_VER */
 
 namespace Autoparam {
 
@@ -575,53 +579,53 @@ void Driver::registerHandlers(std::string const &function,
     m_functionTypes[function] = Handlers<T>::type;
 }
 
-template void
+template epicsShareFunc void
 Driver::registerHandlers<epicsInt32>(std::string const &function,
                                      Handlers<epicsInt32>::ReadHandler reader,
                                      Handlers<epicsInt32>::WriteHandler writer,
                                      InterruptRegistrar intrRegistrar);
-template void
+template epicsShareFunc void
 Driver::registerHandlers<epicsInt64>(std::string const &function,
                                      Handlers<epicsInt64>::ReadHandler reader,
                                      Handlers<epicsInt64>::WriteHandler writer,
                                      InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<epicsFloat64>(
+template epicsShareFunc void Driver::registerHandlers<epicsFloat64>(
     std::string const &function, Handlers<epicsFloat64>::ReadHandler reader,
     Handlers<epicsFloat64>::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<epicsUInt32>(
+template epicsShareFunc void Driver::registerHandlers<epicsUInt32>(
     std::string const &function, Handlers<epicsUInt32>::ReadHandler reader,
     Handlers<epicsUInt32>::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<Octet>(
+template epicsShareFunc void Driver::registerHandlers<Octet>(
     std::string const &function, Handlers<Octet>::ReadHandler reader,
     Handlers<Octet>::WriteHandler writer, InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<Array<epicsInt8> >(
+template epicsShareFunc void Driver::registerHandlers<Array<epicsInt8> >(
     std::string const &function,
     Handlers<Array<epicsInt8> >::ReadHandler reader,
     Handlers<Array<epicsInt8> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<Array<epicsInt16> >(
+template epicsShareFunc void Driver::registerHandlers<Array<epicsInt16> >(
     std::string const &function,
     Handlers<Array<epicsInt16> >::ReadHandler reader,
     Handlers<Array<epicsInt16> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<Array<epicsInt32> >(
+template epicsShareFunc void Driver::registerHandlers<Array<epicsInt32> >(
     std::string const &function,
     Handlers<Array<epicsInt32> >::ReadHandler reader,
     Handlers<Array<epicsInt32> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<Array<epicsInt64> >(
+template epicsShareFunc void Driver::registerHandlers<Array<epicsInt64> >(
     std::string const &function,
     Handlers<Array<epicsInt64> >::ReadHandler reader,
     Handlers<Array<epicsInt64> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<Array<epicsFloat32> >(
+template epicsShareFunc void Driver::registerHandlers<Array<epicsFloat32> >(
     std::string const &function,
     Handlers<Array<epicsFloat32> >::ReadHandler reader,
     Handlers<Array<epicsFloat32> >::WriteHandler writer,
     InterruptRegistrar intrRegistrar);
-template void Driver::registerHandlers<Array<epicsFloat64> >(
+template epicsShareFunc void Driver::registerHandlers<Array<epicsFloat64> >(
     std::string const &function,
     Handlers<Array<epicsFloat64> >::ReadHandler reader,
     Handlers<Array<epicsFloat64> >::WriteHandler writer,
@@ -640,23 +644,23 @@ asynStatus Driver::doCallbacksArray(DeviceVariable const &var, Array<T> &value,
     return doCallbacksArrayDispatch(var.asynIndex(), value);
 }
 
-template asynStatus
+template epicsShareFunc asynStatus
 Driver::doCallbacksArray<epicsInt8>(DeviceVariable const &var,
                                     Array<epicsInt8> &value, asynStatus status,
                                     int alarmStatus, int alarmSeverity);
-template asynStatus Driver::doCallbacksArray<epicsInt16>(
+template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsInt16>(
     DeviceVariable const &var, Array<epicsInt16> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
-template asynStatus Driver::doCallbacksArray<epicsInt32>(
+template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsInt32>(
     DeviceVariable const &var, Array<epicsInt32> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
-template asynStatus Driver::doCallbacksArray<epicsInt64>(
+template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsInt64>(
     DeviceVariable const &var, Array<epicsInt64> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
-template asynStatus Driver::doCallbacksArray<epicsFloat32>(
+template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsFloat32>(
     DeviceVariable const &var, Array<epicsFloat32> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
-template asynStatus Driver::doCallbacksArray<epicsFloat64>(
+template epicsShareFunc asynStatus Driver::doCallbacksArray<epicsFloat64>(
     DeviceVariable const &var, Array<epicsFloat64> &value, asynStatus status,
     int alarmStatus, int alarmSeverity);
 
@@ -685,26 +689,26 @@ asynStatus Driver::setParam(DeviceVariable const &var, epicsUInt32 value,
     return setUIntDigitalParam(var.asynIndex(), value, mask);
 }
 
-template asynStatus Driver::setParam<epicsInt32>(DeviceVariable const &var,
+template epicsShareFunc asynStatus Driver::setParam<epicsInt32>(DeviceVariable const &var,
                                                  epicsInt32 value,
                                                  asynStatus status,
                                                  int alarmStatus,
                                                  int alarmSeverity);
-template asynStatus Driver::setParam<epicsInt64>(DeviceVariable const &var,
+template epicsShareFunc asynStatus Driver::setParam<epicsInt64>(DeviceVariable const &var,
                                                  epicsInt64 value,
                                                  asynStatus status,
                                                  int alarmStatus,
                                                  int alarmSeverity);
-template asynStatus Driver::setParam<epicsFloat64>(DeviceVariable const &var,
+template epicsShareFunc asynStatus Driver::setParam<epicsFloat64>(DeviceVariable const &var,
                                                    epicsFloat64 value,
                                                    asynStatus status,
                                                    int alarmStatus,
                                                    int alarmSeverity);
-template asynStatus Driver::setParam<Octet>(DeviceVariable const &var,
+template epicsShareFunc asynStatus Driver::setParam<Octet>(DeviceVariable const &var,
                                             Octet value, asynStatus status,
                                             int alarmStatus, int alarmSeverity);
 
-template <>
+template <> epicsShareFunc
 asynStatus Driver::setParam<epicsUInt32>(DeviceVariable const &var,
                                          epicsUInt32 value, asynStatus status,
                                          int alarmStatus, int alarmSeverity) {

--- a/autoparamDriverSup/src/autoparamDriver.cpp
+++ b/autoparamDriverSup/src/autoparamDriver.cpp
@@ -12,10 +12,6 @@
 #include <epicsExport.h>
 #include "autoparamDriver.h"
 
-#ifdef _MSC_VER
-#define __attribute__(x)
-#endif /* ifdef _MSC_VER */
-
 namespace Autoparam {
 
 static char const *driverName = "Autoparam::Driver";
@@ -82,9 +78,8 @@ static void runInitHooks(initHookState state) {
 }
 
 static void addInitHook(Driver *driver, DriverOpts::InitHook hook) {
-    static int const isRegistered __attribute__((unused)) =
-        initHookRegister(runInitHooks);
-
+    static int const isRegistered = initHookRegister(runInitHooks);
+    (void)isRegistered;
     allInitHooks[driver] = hook;
 }
 

--- a/autoparamDriverSup/src/autoparamDriver.h
+++ b/autoparamDriverSup/src/autoparamDriver.h
@@ -24,7 +24,7 @@ class Driver;
  *                        .setAutoInterrupts(false)
  *                        .setPriority(epicsThreadPriorityLow));
  */
-class epicsShareClass DriverOpts {
+class AUTOPARAMDRIVER_API DriverOpts {
   public:
     //! A function that can be set to run after IOC init.
     typedef void (*InitHook)(Driver *);
@@ -241,7 +241,7 @@ class epicsShareClass DriverOpts {
  * `Driver::deviceVariableFromUser()` is provided to obtain `DeviceVariable`
  * from the `asynUser` pointer that `asynPortDriver` methods are provided.
  */
-class epicsShareClass Driver : public asynPortDriver {
+class AUTOPARAMDRIVER_API Driver : public asynPortDriver {
   public:
     /*! Constructs the `Driver` with the given options.
      *

--- a/autoparamDriverSup/src/autoparamDriver.h
+++ b/autoparamDriverSup/src/autoparamDriver.h
@@ -503,7 +503,7 @@ class AUTOPARAMDRIVER_API Driver : public asynPortDriver {
     template <typename T> std::map<std::string, Handlers<T> > &getHandlerMap();
 
     template <typename Iface, typename HType>
-    void installAnInterruptRegistrar(void *piface);
+    void installAnInterruptRegistrar(void *&piface);
     void installInterruptRegistrars();
     template <typename T>
     static asynStatus registerInterrupt(void *drvPvt, asynUser *pasynUser,
@@ -528,6 +528,7 @@ class AUTOPARAMDRIVER_API Driver : public asynPortDriver {
     typedef void (*VoidFuncPtr)(void);
     std::map<asynParamType, std::pair<VoidFuncPtr, VoidFuncPtr> >
         m_originalIntrRegister;
+    std::vector<void*> m_hijackedInterfaces;
     std::map<DeviceVariable *, int> m_interruptRefcount;
 
     std::map<std::string, Handlers<epicsInt32> > m_Int32HandlerMap;

--- a/autoparamDriverSup/src/autoparamDriver.h
+++ b/autoparamDriverSup/src/autoparamDriver.h
@@ -503,7 +503,7 @@ class epicsShareClass Driver : public asynPortDriver {
     template <typename T> std::map<std::string, Handlers<T> > &getHandlerMap();
 
     template <typename Iface, typename HType>
-    void installAnInterruptRegistrar(void *interface);
+    void installAnInterruptRegistrar(void *piface);
     void installInterruptRegistrars();
     template <typename T>
     static asynStatus registerInterrupt(void *drvPvt, asynUser *pasynUser,

--- a/autoparamDriverSup/src/autoparamDriverAPI_prebuilt.h
+++ b/autoparamDriverSup/src/autoparamDriverAPI_prebuilt.h
@@ -1,0 +1,34 @@
+/* This is a generated file, do not edit! */
+/* This file was pre-built for compatibility with EPICS older than 7.0.4 */
+
+#ifndef INC_autoparamDriverAPI_H
+#define INC_autoparamDriverAPI_H
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#  if !defined(epicsStdCall)
+#    define epicsStdCall __stdcall
+#  endif
+
+#  if defined(BUILDING_autoparamDriver_API) && defined(EPICS_BUILD_DLL)
+/* Building library as dll */
+#    define AUTOPARAMDRIVER_API __declspec(dllexport)
+#  elif !defined(BUILDING_autoparamDriver_API) && defined(EPICS_CALL_DLL)
+/* Calling library in dll form */
+#    define AUTOPARAMDRIVER_API __declspec(dllimport)
+#  endif
+
+#elif __GNUC__ >= 4
+#  define AUTOPARAMDRIVER_API __attribute__ ((visibility("default")))
+#endif
+
+#if !defined(AUTOPARAMDRIVER_API)
+#  define AUTOPARAMDRIVER_API
+#endif
+
+#if !defined(epicsStdCall)
+#  define epicsStdCall
+#endif
+
+#endif /* INC_autoparamDriverAPI_H */
+

--- a/autoparamDriverSup/src/autoparamHandler.h
+++ b/autoparamDriverSup/src/autoparamHandler.h
@@ -13,7 +13,9 @@
 #include <asynPortDriver.h>
 #include <alarm.h>
 #include <epicsTypes.h>
-#include <shareLib.h>
+
+// API definition
+#include <autoparamDriverAPI.h>
 
 namespace Autoparam {
 
@@ -35,7 +37,7 @@ namespace Autoparam {
  * A `DeviceAddress` must be equality-comparable to other addresses. Two
  * addresses shall compare equal when they refer to the same device variable.
  */
-class epicsShareClass DeviceAddress {
+class AUTOPARAMDRIVER_API DeviceAddress {
   public:
     virtual ~DeviceAddress() {}
 
@@ -57,7 +59,7 @@ class epicsShareClass DeviceAddress {
  * shared between records referring to the same device variable. They are
  * destroyed when the driver is destroyed.
  */
-class epicsShareClass DeviceVariable {
+class AUTOPARAMDRIVER_API DeviceVariable {
   public:
     /*! Construct `DeviceVariable` from another; the other one is invalidated.
      *

--- a/autoparamTestApp/src/Makefile
+++ b/autoparamTestApp/src/Makefile
@@ -9,7 +9,7 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
-USR_CXXFLAGS += --std=c++03
+USR_CXXFLAGS_Linux += --std=c++03
 
 #=============================
 # Build the IOC application

--- a/autoparamTestApp/src/autoparamTest.cpp
+++ b/autoparamTestApp/src/autoparamTest.cpp
@@ -7,8 +7,13 @@
 #include <ctime>
 #include <cstdlib>
 #include <iocsh.h>
-#include <epicsExport.h>
 #include <epicsThread.h>
+#include <epicsExport.h>
+
+#ifdef _MSC_VER
+// rand_r() does not exist on windows, could maybe use rand_s() ?
+#define rand_r(x) rand()
+#endif /* ifdef _MSC_VER */
 
 using namespace Autoparam::Convenience;
 
@@ -263,7 +268,7 @@ class AutoparamTest : public Autoparam::Driver {
         return WriteResult();
     }
 
-    uint randomSeed;
+    unsigned randomSeed;
     epicsInt32 currentSum;
     std::vector<epicsInt8> wfm8Data;
     epicsUInt32 shiftedRegister;

--- a/autoparamTestApp/src/autoparamTest.cpp
+++ b/autoparamTestApp/src/autoparamTest.cpp
@@ -11,7 +11,7 @@
 #include <epicsExport.h>
 
 #ifdef _MSC_VER
-// rand_r() does not exist on windows, could maybe use rand_s() ?
+// Windows doesn't have rand_r, instead it reseeds rand, so it's ok.
 #define rand_r(x) rand()
 #endif /* ifdef _MSC_VER */
 


### PR DESCRIPTION
Changes for building on Windows - please check they still work on Linux

* add `epicsShareFunc` to export the templates from the DLL
* change `interface` to `piface`  to avoid name clash